### PR TITLE
New user service endpoint

### DIFF
--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -39,6 +39,7 @@ const Endpoints = Object.freeze({
     UNINDEX: "management/tasks/unindex",
     REMOVE: "management/tasks/remove",
     TASKS: "index/task",
+    USER: "user",
     VERSION: "ext/version",
     LOGGER: "logger",
     LOGIN: "login",

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import Endpoints from './endpoints';
 import {Socket} from './socket';
 import {StorageService, QueryRetrieveService} from './service';
 import {Tasks} from './tasks';
+import {UserService} from './users';
 import {andCall, andCallVoid, isDicomUUID} from './util';
 import {SuperAgentRequest} from 'superagent';
 
@@ -277,6 +278,8 @@ class DicoogleAccess {
   public storage: StorageService;
   /** Query/Retrieve service namespace */
   public queryRetrieve: QueryRetrieveService;
+  /** users service namespace */
+  public users: UserService;
 
   /**
    * Perform a text query.
@@ -893,6 +896,7 @@ function dicoogleClient(url?: string, options: DicoogleClientOptions = {}): Dico
     m.tasks = new Tasks(socket_);
     m.storage = new StorageService(socket_);
     m.queryRetrieve = new QueryRetrieveService(socket_);
+    m.users = new UserService(socket_);
 
     return m;
 }

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -127,6 +127,14 @@ export class Socket {
         return this.request('POST', uri);
     }
 
+    /** Create a PUT request to Dicoogle.
+     * @param uri - the URI to the intended service, relative to Dicoogle's base URL
+     * @returns a superagent object for a new request to this service
+     */
+    public put(uri: string | string[]): SuperAgentRequest {
+        return this.request('PUT', uri);
+    }
+
     public getToken(): string | null {
         return this._token;
     }

--- a/src/users.ts
+++ b/src/users.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2017  Universidade de Aveiro, DETI/IEETA, Bioinformatics Group - http://bioinformatics.ua.pt/
+ *
+ * This file is part of Dicoogle/dicoogle-client-js.
+ *
+ * Dicoogle/dicoogle-client-js is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Dicoogle/dicoogle-client-js is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Dicoogle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Endpoints from './endpoints';
+import {Socket} from './socket';
+import {andCall} from './util';
+
+export type password = string;
+
+export interface User {
+    username: string,
+    roles?: string[],
+    admin?: boolean,
+}
+
+export class UserService {
+    private socket: Socket;
+  
+    constructor(socket) {
+      this.socket = socket;
+    }
+
+    /** List all registered users.
+     */
+    list(callback?: (error: Error | null, users?: User[]) => void): Promise<User[]> {
+        return andCall(this.socket.get(Endpoints.USER)
+            .then((res) => res.body.users), callback)
+    }
+
+    /** Create a new user for Dicoogle.
+     * 
+     * @param username the new identifier of the user
+     * @param password the new password
+     * @param admin whether the account is an administrator
+     */
+    add(username: string, password: password, admin: boolean, callback?: (error: Error | null, success?: boolean) => void): Promise<boolean> {
+        return andCall(this.socket.put(Endpoints.USER).query({username, password, admin})
+            .then((res) => res.body.success), callback);
+    }
+
+    /** Remove an existing user from the platorm.
+     * 
+     * @param username the identifier of the user to remove
+     */
+    remove(username: string, callback?: (error: Error | null, removed?: boolean) => void): Promise<boolean> {
+        return andCall(this.socket.request('DELETE', Endpoints.USER).query({username})
+            .then((res) => res.body.success), callback);
+    }
+}
+  

--- a/test/mock/service-mock.js
+++ b/test/mock/service-mock.js
@@ -23,7 +23,7 @@ const URL = require('url');
 const qs = require('querystring');
 
 /** Use nock to intercept Dicoogle client requests.
- * @param {number} [port]
+ * @param {number} [port] the TCP port to listen to
  * @returns {object} a Dicoogle access object Dicoogle access object connected to a mock Dicoogle server.
  */
 module.exports = function createDicoogleMock(port = 8080) {
@@ -604,6 +604,35 @@ module.exports = function createDicoogleMock(port = 8080) {
                 AETitle = String(qs.parse(qstring).aetitle).trim();
                 return 'success';
             });
+        
+        nock(BASE_URL)
+            .get('/user')
+            .reply(200, {users: [
+                { username: "dicoogle" },
+                { username: "other" }
+            ]})
+            .put('/user')
+            .query(({username, password, admin}) => {
+                return username === 'drze' &&
+                    typeof password === 'string' &&
+                    password.length > 0 &&
+                    (admin === undefined || admin === 'true' || admin === 'false');
+            })
+            .reply(200, {success: true})
+            .get('/user')
+            .reply(200, {users: [
+                { username: "dicoogle" },
+                { username: "drze" },
+                { username: "other" }
+            ]})
+            .delete('/user')
+            .query({username: 'drze'})
+            .reply(200, {success: true})
+            .get('/user')
+            .reply(200, {users: [
+                { username: "dicoogle" },
+                { username: "other" }
+            ]});
 
     return dicoogleClient(BASE_URL);
 };

--- a/test/test-base-promise.js
+++ b/test/test-base-promise.js
@@ -342,6 +342,35 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
     });
   });
 
+  describe('User management service', () => {
+    it('#list should provide the list of users', async () => {
+      let users = await dicoogle.users.list();
+      assert.isArray(users);
+      for (const u of users) {
+        assert.property(u, 'username');
+      }
+    });
+
+    it('#add and #remove should add and remove users', async () => {
+      // add a new user
+      let addSuccess = await dicoogle.users.add('drze', 'verygoodsecret', false);
+      assert.isTrue(addSuccess);
+
+      // check that the user now exists
+      let users;
+      users = await dicoogle.users.list();
+      assert.deepInclude(users, {username: 'drze'});
+
+      // now remove the user
+      let removeSuccess = await dicoogle.users.remove('drze');
+      assert.isTrue(removeSuccess);
+
+      // check the list again
+      users = await dicoogle.users.list();
+      assert.notDeepInclude(users, {username: 'drze'});
+    });
+  });
+
   describe('Storage service', function() {
     describe('#storage.getStatus()', function() {
       it("should inform of DICOM Storage service status with no error", async function() {
@@ -551,6 +580,6 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
       assert.isObject(data);
       assert.propertyVal(data, 'version', DICOOGLE_VERSION);
     });
-  })
+  });
 });
 

--- a/test/test-base.js
+++ b/test/test-base.js
@@ -487,6 +487,54 @@ describe('Dicoogle Client, callback API (under Node.js)', function() {
     });
   });
 
+  describe('User management service', () => {
+    it('#list should provide the list of users', (done) => {
+      try {
+        Dicoogle.users.list((err, users) => {
+          assert.ifError(err);
+          assert.isArray(users);
+          for (const u of users) {
+            assert.property(u, 'username');
+          }
+          done()
+        });
+      } catch (err) {
+        done(err);
+      }
+    });
+
+    it('#add and #remove should add and remove users', (done) => {
+      try {
+        // add a new user
+        Dicoogle.users.add('drze', 'verygoodsecret', false, (err, success) => {
+          assert.ifError(err);
+          assert.isTrue(success);
+
+          // check that the user now exists
+          Dicoogle.users.list((err, users) => {
+            assert.ifError(err);
+            assert.deepInclude(users, {username: 'drze'});
+
+            // now remove the user
+            Dicoogle.users.remove('drze', (err, success) => {
+              assert.ifError(err);
+              assert.isTrue(success);
+
+              // check the list again
+              Dicoogle.users.list((err, users) => {
+                assert.ifError(err);
+                assert.notDeepInclude(users, {username: 'drze'});
+                done()
+              });
+            });
+          });
+        });
+      } catch (err) {
+        done(err);
+      }
+    });
+  });
+
   describe('Storage service', function() {
     describe('#storage.getStatus()', function() {
         it("should inform of DICOM Storage service status with no error", function(done) {


### PR DESCRIPTION
This PR adds methods for listing, adding, and removing users under the `users` namespace.

The web API for this already exists since Dicoogle 2.0, but a UI for this was never constructed.