### PR TITLE
Make bundle standalone

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -73,7 +73,8 @@ function bundle() {
           NODE_ENV: "production"
         }
       ]
-    ]
+    ],
+    standalone: 'DicoogleClient'
   });
   return b
     .bundle()


### PR DESCRIPTION
Explicitly make the bundle in `dist/dicoogle-client.min.js` standalone, so that it exports a global variable `DicoogleClient`. It used to be like this, but there was probably a regression in an update. The example in `example/app.html` works again with this.