### PR TITLE
Fix type definition of ServiceStatus

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -21,22 +21,34 @@ import Endpoints from './endpoints';
 import {Socket} from './socket';
 import {andCall, andCallVoid} from './util';
 
+/** Configuration object for a DICOM service. */
 export interface ServiceConfiguration {
-  /// whether the service is currently running
+  /** whether to enable or disable the service */
   running?: boolean,
-  /// whether the service starts automatically
+  /** whether the service should start automatically */
   autostart?: boolean,
-  ///the TCP port that the service listens to
+  /** the TCP port that the service should listen to */
   port?: number,
 }
 
+/** Full status of the DICOM service. */
 export interface ServiceStatus {
-  /// whether the service is currently running
-  running: boolean,
-  /// whether the service starts automatically
+  /** whether the service is currently running */
+  isRunning: boolean,
+  /** whether the service starts automatically */
   autostart: boolean,
-  /// the TCP port that the service listens to
+  /** the TCP port that the service listens to */
   port: number,
+}
+
+/** A DICOM service change outcome object,
+ * obtained when changing one or more properties of a service.
+ * 
+ * If successful, the properties changed will be replicated in this object.
+ */
+export interface ServiceChangeOutcome extends ServiceConfiguration {
+  /** whether the DICOM service update was successful */
+  success: boolean,
 }
 
 export interface RemoteStorage {
@@ -81,10 +93,11 @@ class BaseService {
    * @param config a set of properties to configure
    * @param callback the callback function
    */
-  configure(config: ServiceConfiguration, callback?: (error: Error | null) => void): Promise<void> {
+  configure(config: ServiceConfiguration, callback?: (error: Error | null) => void): Promise<ServiceChangeOutcome> {
     const {running, autostart, port} = config;
-    return andCallVoid(this._socket.post(this._endpoint)
-      .query({running, autostart, port}), callback);
+    return andCall(this._socket.post(this._endpoint)
+      .query({running, autostart, port})
+      .then((resp) => resp.body), callback);
   }
 
   /**

--- a/test/mock/service-mock.js
+++ b/test/mock/service-mock.js
@@ -178,12 +178,12 @@ module.exports = function createDicoogleMock(port = 8080) {
 
         let AETitle = 'TESTSRV';
         let Storage = {
-            running: true,
+            isRunning: true,
             autostart: false,
             port: 6666
         };
         let QR = {
-            running: true,
+            isRunning: true,
             autostart: false,
             port: 1045
         };
@@ -478,14 +478,20 @@ module.exports = function createDicoogleMock(port = 8080) {
             .post('/management/dicom/query')
             .query({ running: 'false' })
             .reply(200, function() {
-                QR.running = false;
-                return "success";
+                QR.isRunning = false;
+                return {
+                    success: true,
+                    running: false
+                };
             })
             .post('/management/dicom/query')
             .query({ running: true })
             .reply(200, function() {
-                QR.running = true;
-                return "success";
+                QR.isRunning = true;
+                return {
+                    success: true,
+                    running: true
+                };
             });
 
         nock(BASE_URL)
@@ -502,7 +508,11 @@ module.exports = function createDicoogleMock(port = 8080) {
             .reply(200, function() {
                 QR.autostart = true;
                 QR.port = 7777;
-                return "success";
+                return {
+                    success: true,
+                    autostart: true,
+                    port: 7777
+                };
             })
 
 
@@ -515,21 +525,31 @@ module.exports = function createDicoogleMock(port = 8080) {
             .post('/management/dicom/storage')
             .query({ running: false })
             .reply(200, function() {
-                Storage.running = false;
-                return "success";
+                Storage.isRunning = false;
+                return {
+                    success: true,
+                    running: true
+                };
             })
             .post('/management/dicom/storage')
             .query({ running: true })
             .reply(200, function() {
-                Storage.running = true;
-                return "success";
+                Storage.isRunning = true;
+                return {
+                    success: true,
+                    running: true
+                };
             })
             .post('/management/dicom/storage')
             .query({ autostart: true, port: 7777 })
             .reply(200, function() {
                 Storage.autostart = true;
                 Storage.port = 7777;
-                return "success";
+                return {
+                    success: true,
+                    autostart: true,
+                    port: 7777
+                };
             });
 
         // mock storage servers

--- a/test/test-base-promise.js
+++ b/test/test-base-promise.js
@@ -358,7 +358,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
   });
 
   function checkServiceInfo(data) {
-    assert.isBoolean(data.running, 'running must be a boolean');
+    assert.isBoolean(data.isRunning, 'isRunning must be a boolean');
     assert.isBoolean(data.autostart, 'autostart must be a boolean');
     assert.strictEqual(data.port | 0, data.port, 'port must be an integer');
   }
@@ -374,18 +374,18 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
       it("should give no error", async function() {
         await dicoogle.queryRetrieve.stop();
       });
-      it("and running = false", async function() {
+      it("and isRunning = false", async function() {
         let data = await dicoogle.queryRetrieve.getStatus();
-        assert.strictEqual(data.running, false);
+        assert.strictEqual(data.isRunning, false);
       });
     });
     describe('#queryRetrieve.start()', function() {
         it("should give no error", async function() {
           await dicoogle.queryRetrieve.start();
         });
-        it("and running = true", async function() {
+        it("and isRunning = true", async function() {
           let data = await dicoogle.queryRetrieve.getStatus();
-          assert.strictEqual(data.running, true);
+          assert.strictEqual(data.isRunning, true);
         });
     });
     describe('queryRetrieve#configure()', function() {
@@ -459,27 +459,30 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
       it("should give no error", async function() {
         await dicoogle.storage.stop();
       });
-      it("and running = false", async function() {
+      it("and isRunning = false", async function() {
         let data = await dicoogle.storage.getStatus();
-        assert.strictEqual(data.running, false);
+        assert.strictEqual(data.isRunning, false);
       });
     });
     describe('storage#start()', function() {
       it("should give no error", async function() {
         await dicoogle.storage.start();
       });
-      it("and running = true", async function() {
+      it("and isRunning = true", async function() {
         let data = await dicoogle.storage.getStatus();
-        assert.strictEqual(data.running, true);
+        assert.strictEqual(data.isRunning, true);
       });
     });
 
     describe('storage#configure()', function() {
       it("should give no error", async function() {
-        await dicoogle.storage.configure({
+        let outcome = await dicoogle.storage.configure({
           autostart: true,
           port: 7777
         });
+        assert.strictEqual(outcome.success, true);
+        assert.strictEqual(outcome.autostart, true);
+        assert.strictEqual(outcome.port, 7777);
       });
       it("and {autostart, port} changes", async function() {
         let data = await dicoogle.storage.getStatus();

--- a/test/test-base.js
+++ b/test/test-base.js
@@ -496,7 +496,7 @@ describe('Dicoogle Client, callback API (under Node.js)', function() {
 
   function checkServiceInfo(error, data) {
     assert.equal(error, null);
-    assert.isBoolean(data.running, 'running must be a boolean');
+    assert.isBoolean(data.isRunning, 'isRunning must be a boolean');
     assert.isBoolean(data.autostart, 'autostart must be a boolean');
     assert.strictEqual(data.port | 0, data.port, 'port must be an integer');
   }
@@ -517,10 +517,10 @@ describe('Dicoogle Client, callback API (under Node.js)', function() {
                 done();
             });
         });
-        it("and running = false", function(done) {
+        it("and isRunning = false", function(done) {
             Dicoogle.queryRetrieve.getStatus(function (error, data) {
                 assert.equal(error, null);
-                assert.strictEqual(data.running, false);
+                assert.strictEqual(data.isRunning, false);
                 done();
             });
         });
@@ -532,10 +532,10 @@ describe('Dicoogle Client, callback API (under Node.js)', function() {
                 done();
             })
         });
-        it("and running = true", function(done) {
+        it("and isRunning = true", function(done) {
             Dicoogle.queryRetrieve.getStatus(function (error, data) {
                 assert.equal(error, null);
-                assert.strictEqual(data.running, true);
+                assert.strictEqual(data.isRunning, true);
                 done();
             })
         });
@@ -545,8 +545,11 @@ describe('Dicoogle Client, callback API (under Node.js)', function() {
             Dicoogle.queryRetrieve.configure({
                 autostart: true,
                 port: 7777
-            }, function (error) {
+            }, function (error, outcome) {
                 assert.equal(error, null);
+                assert.strictEqual(outcome.success, true);
+                assert.strictEqual(outcome.autostart, true);
+                assert.strictEqual(outcome.port, 7777);
                 done();
             });
         });
@@ -648,10 +651,10 @@ describe('Dicoogle Client, callback API (under Node.js)', function() {
                 done();
             })
         });
-        it("and running = false", function(done) {
+        it("and isRunning = false", function(done) {
             Dicoogle.storage.getStatus(function (error, data) {
                 assert.equal(error, null);
-                assert.strictEqual(data.running, false);
+                assert.strictEqual(data.isRunning, false);
                 done();
             })
         });
@@ -663,10 +666,10 @@ describe('Dicoogle Client, callback API (under Node.js)', function() {
                 done();
             });
         });
-        it("and running = true", function(done) {
+        it("and isRunning = true", function(done) {
             Dicoogle.storage.getStatus(function (error, data) {
                 assert.equal(error, null);
-                assert.strictEqual(data.running, true);
+                assert.strictEqual(data.isRunning, true);
                 done();
             })
         });


### PR DESCRIPTION
This was a mistake which either leaked into or from the OpenAPI specification itself (bioinformatics-ua/dicoogle#591). When retrieving the DICOM service status via GET, the property is called `isRunning` instead of `running`.

Summary:

- change `ServiceStatus` definition
- fix tests accordingly
   - fix mock responses
- improve documentation in service module
- change configure to return outcome response
