### PR TITLE
Fix type definition of SearchResult

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -144,8 +144,17 @@ interface ExportOptions {
 
 type DIMLevel = "none" | "patient" | "study" | "series" | "image";
 
+/** An entry in the list of search results. */
 interface SearchResult {
-  [attribute: string]: any,
+  /** A dictionary of DICOM fields of this item,
+   * indexed by DICOM tag keyword such as `SOPInstanceUID` and `Modality`.
+   * 
+   * Which fields are present depends on the list of requested fields.
+   */
+  fields: {
+    [attribute: string]: string,
+  },
+  /** The unique URI which identifies the item in storage. */
   uri: string,
   score?: number,
 }


### PR DESCRIPTION
Each search result contains a fields attribute, in which one may then find the DICOM fields.
This was validated from observing Dicoogle core code and real server outputs.
