### PR TITLE
Fix operations to add and delete users

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -38,6 +38,7 @@
     "eol-last": 1,
     "no-undef": 2,
     "valid-jsdoc": 0,
+    "@typescript-eslint/no-var-requires": 0,
     "@typescript-eslint/no-unused-vars": [1, {
       "args": "none",
       "vars": "local",

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -7,9 +7,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, release/5.x ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, release/5.x ]
 
 jobs:
   build:

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "vinyl-source-stream": "^2.0.0"
   },
   "scripts": {
-    "check": "eslint --fix src/ test/*.js test/mock/*.js",
+    "check": "eslint --fix src/ test/*.ts test/mock/*.ts",
+    "strictCheck": "eslint src/ test/*.ts test/mock/*.ts",
     "build": "npm run check && npm run prepare && gulp bundle",
     "prepare": "tsc",
     "clean": "rimraf dist lib coverage .nyc_output docs",

--- a/src/users.ts
+++ b/src/users.ts
@@ -50,7 +50,15 @@ export class UserService {
      * @param admin whether the account is an administrator
      */
     add(username: string, password: password, admin: boolean, callback?: (error: Error | null, success?: boolean) => void): Promise<boolean> {
-        return andCall(this.socket.put(Endpoints.USER).query({username, password, admin})
+        return andCall(this.socket.post(Endpoints.USER).query({username, password, admin})
+            .catch((err) => {
+                if (err.status === 405) {
+                    // method not allowed means that we're using Dicoogle 2,
+                    // so we try again with the PUT method
+                    return this.socket.put(Endpoints.USER).query({username, password, admin});
+                }
+                throw err;
+            })
             .then((res) => res.body.success), callback);
     }
 

--- a/src/users.ts
+++ b/src/users.ts
@@ -59,7 +59,7 @@ export class UserService {
      * @param username the identifier of the user to remove
      */
     remove(username: string, callback?: (error: Error | null, removed?: boolean) => void): Promise<boolean> {
-        return andCall(this.socket.request('DELETE', Endpoints.USER).query({username})
+        return andCall(this.socket.request('DELETE', [Endpoints.USER, username])
             .then((res) => res.body.success), callback);
     }
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,11 +1,19 @@
 {
   "root": true,
-  "extends": "eslint:recommended",
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
   "parserOptions": {
     "ecmaVersion": 2017,
     "sourceType": "module"
   },
+  "parser": "@typescript-eslint/parser",
+  "plugins": [
+    "@typescript-eslint"
+  ],
   "env": {
+    "commonjs": true,
     "node": true,
     "es6": true
   },
@@ -16,13 +24,15 @@
   "rules": {
     "no-alert": 2,
     "no-console": 1,
+    "@typescript-eslint/no-var-requires": 0,
+    "@typescript-eslint/no-non-null-assertion": 0,
     "quotes": 0,
     "curly": 0,
     "global-strict": 0,
     "new-cap": 0,
     "camelcase": 0,
     "comma-dangle": 0,
-    "no-unused-vars": 1,
+    "no-unused-vars": 0,
     "comma-spacing": 1,
     "space-infix-ops": 1,
     "no-mixed-spaces-and-tabs": 1,

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -20,10 +20,10 @@
 /* eslint-env mocha */
 import {assert} from 'chai';
 import createMockedDicoogle from './mock/service-auth-mock';
-var UUID_REGEXP = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
+const UUID_REGEXP = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
 
 describe('Dicoogle Authentication', function() {
-  var Dicoogle;
+  let Dicoogle;
   function initBaseURL() {
     Dicoogle = createMockedDicoogle();
     assert.strictEqual(Dicoogle.getBase(), 'http://127.0.0.1:8484');
@@ -115,7 +115,7 @@ describe('Dicoogle Authentication', function() {
   });
 
   describe('Loading a previous session', function() {
-    var TOKEN = '00000000-0000-0000-0000-000000000001';
+    const TOKEN = '00000000-0000-0000-0000-000000000001';
     it('#setToken(string) should modify the session token', function() {
       Dicoogle.setToken(TOKEN);
       assert.strictEqual(Dicoogle.getToken(), TOKEN);
@@ -136,7 +136,7 @@ describe('Dicoogle Authentication', function() {
     });
 
     it("clear and restore previous session ; should give user name, admin and roles", function(done) {
-        var token = Dicoogle.getToken();
+        const token = Dicoogle.getToken();
         Dicoogle.reset();
 
         Dicoogle.restoreSession(token, function(error, data) {

--- a/test/base-promise.test.ts
+++ b/test/base-promise.test.ts
@@ -561,8 +561,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
         }
       }
     }
-    it("should give transfer syntax settings (2.3.1)", testTransferSettings);
-    it("should give transfer syntax settings (patched)", testTransferSettings);
+    it("should give transfer syntax settings", testTransferSettings);
   });
 
   describe('#setTransferSyntaxOption() an option', function() {

--- a/test/base-promise.test.ts
+++ b/test/base-promise.test.ts
@@ -40,14 +40,14 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
 
   describe('#getVersion()', function() {
     it("should give Dicoogle's version with no error", async function() {
-      let {version} = await dicoogle.getVersion();
+      const {version} = await dicoogle.getVersion();
       assert.strictEqual(version, DICOOGLE_VERSION);
     });
   });
 
   describe('Get Log', function() {
     it("#getRawLog() should provide log text with no error", async function() {
-      let text = await dicoogle.getRawLog();
+      const text = await dicoogle.getRawLog();
       assert.isString(text);
     });
   });
@@ -55,13 +55,13 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
   describe('Get Query Providers', function() {
     describe('using #getQueryProviders()', function() {
       it("should give 'lucene' and 'cbir' with no error", async function() {
-        let providers = await dicoogle.getQueryProviders();
+        const providers = await dicoogle.getQueryProviders();
         assert.sameMembers(providers, ['lucene', 'cbir']);
       });
     });
     describe('using #getProviders(function)', function() {
       it("should give 'lucene' and 'cbir' with no error", async function() {
-        let providers = await dicoogle.getProviders();
+        const providers = await dicoogle.getProviders();
         assert.sameMembers(providers, ['lucene', 'cbir']);
       });
     });
@@ -69,14 +69,14 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
 
   describe('Get Index Providers', function() {
     it("#getIndexProviders()", async function() {
-      let providers = await dicoogle.getIndexProviders();
+      const providers = await dicoogle.getIndexProviders();
       assert.sameMembers(providers, ['lucene', 'cbir']);
     });
   });
 
   describe('Get Storage Providers', function() {
     it("#getStorageProviders()", async function() {
-      let providers = await dicoogle.getStorageProviders();
+      const providers = await dicoogle.getStorageProviders();
       assert.sameMembers(providers, ['file', 'dropbox']);
     });
   });
@@ -84,13 +84,13 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
   describe('Tasks', function() {
 
     it("tasks#list() before changes", async function() {
-      let outcome = await dicoogle.tasks.list();
+      const outcome = await dicoogle.tasks.list();
       assert.isNumber(outcome.count);
       assert.isArray(outcome.tasks);
       assert.strictEqual(outcome.tasks.length, 2);
       assert(outcome.count <= outcome.tasks.length);
       for (let i = 0; i < outcome.tasks.length; i++) {
-        let task = outcome.tasks[i];
+        const task = outcome.tasks[i];
         assert.isObject(task);
         assert.isString(task.taskUid);
         assert.isString(task.taskName);
@@ -108,11 +108,11 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
     it("tasks#close() should successfully clear the task", async function() {
       await dicoogle.tasks.close('f1b6588d-92c2-458c-8c77-e30d8706b662');
 
-      let outcome = await dicoogle.tasks.list();
+      const outcome = await dicoogle.tasks.list();
       assert.isArray(outcome.tasks);
       assert.strictEqual(outcome.tasks.length, 1);
       assert.strictEqual(outcome.count, 1);
-      let task = outcome.tasks[0];
+      const task = outcome.tasks[0];
       assert.isObject(task);
       assert.isString(task.taskUid);
       assert.notEqual(task.taskUid, 'f1b6588d-92c2-458c-8c77-e30d8706b662');
@@ -120,7 +120,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
 
     it("tasks#stop() should successfully clear the task", async function() {
       await dicoogle.tasks.stop('1063922f-1823-4e43-8241-c84c1721a6c1');
-      let outcome = await dicoogle.tasks.list();
+      const outcome = await dicoogle.tasks.list();
       assert.deepEqual(outcome.tasks, []);
       assert.strictEqual(outcome.count, 0);
     });
@@ -130,7 +130,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
     function handleOutcome(outcome) {
         assert.property(outcome, 'results', 'outcome has results');
         assert.isArray(outcome.results, 'results must be an array');
-        for (var i = 0; i < outcome.results.length; i++) {
+        for (let i = 0; i < outcome.results.length; i++) {
             assert.isObject(outcome.results[i], 'all results must be objects');
             assert.isObject(outcome.results[i].fields, 'all results must have a fields object');
             assert.strictEqual(outcome.results[i].fields.Modality, 'MR', 'all results must be MR');
@@ -140,12 +140,12 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
     }
 
     it("takes a keyword-based query and gives results successfully", async function() {
-      let outcome = await dicoogle.search('Modality:MR', {provider: 'lucene', keyword: true});
+      const outcome = await dicoogle.search('Modality:MR', {provider: 'lucene', keyword: true});
       handleOutcome(outcome);
     });
 
     it("auto-detects a keyword-based query and gives results successfully", async function() {
-      let outcome = await dicoogle.search('Modality:MR', {provider: 'lucene'});
+      const outcome = await dicoogle.search('Modality:MR', {provider: 'lucene'});
       handleOutcome(outcome);
     });
   });
@@ -156,11 +156,11 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
         assert.property(outcome, 'results', 'outcome has results');
         assert.isArray(outcome.results, 'results must be an array');
         for (let i = 0; i < outcome.results.length; i++) {
-            let patient = outcome.results[i];
+            const patient = outcome.results[i];
             assert.isObject(patient, 'all patients must be objects');
             assert.isArray(patient.studies, 'all patients must have a studies array');
             for (let j = 0; j < patient.studies.length; j++) {
-                let study = patient.studies[i];
+                const study = patient.studies[i];
                 assert.isObject(study, 'all studies must be objects');
                 assertDicomUUID(study.studyInstanceUID);
                 assert.isArray(study.series, 'all studies must have a series array');
@@ -171,19 +171,19 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
     }
 
     it("with options, gives results successfully", async function() {
-      let outcome = await dicoogle.searchDIM('Modality:MR', {provider: 'lucene', keyword: true});
+      const outcome = await dicoogle.searchDIM('Modality:MR', {provider: 'lucene', keyword: true});
       handleResponse(outcome);
     });
 
     it("without options, gives results successfully", async function() {
-      let outcome = await dicoogle.searchDIM('Modality:MR');
+      const outcome = await dicoogle.searchDIM('Modality:MR');
       handleResponse(outcome);
     });
   });
 
   describe('#search() free text', function() {
     it("should auto-detect a free text query and give some results with no error", async function() {
-      let outcome = await dicoogle.search('Esquina');
+      const outcome = await dicoogle.search('Esquina');
       assert.property(outcome, 'results', 'outcome has results');
       assert.isArray(outcome.results, 'results must be an array');
       for (let i = 0; i < outcome.results.length; i++) {
@@ -251,7 +251,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
 
   describe('#dump()', function() {
     it("should give one result with no error", async function() {
-      let outcome = await dicoogle.dump('1.2.3.4.5.6.7777777.4444.1');
+      const outcome = await dicoogle.dump('1.2.3.4.5.6.7777777.4444.1');
       assert.property(outcome, 'results', 'outcome has results');
       assert.isObject(outcome.results, 'results must be an object');
       assert.isObject(outcome.results.fields, 'must have a fields object');
@@ -261,22 +261,22 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
 
   describe('#issueExport()', function() {
     it("array of fields + options - should give a UID", async function() {
-      let uid = await dicoogle.issueExport('Modality:MR', ['Modality', 'PatientName'], {keyword: true});
+      const uid = await dicoogle.issueExport('Modality:MR', ['Modality', 'PatientName'], {keyword: true});
       assert.isString(uid, 'uid must be a string');
     });
     it("array of fields - should give a UID", async function() {
-      let uid = await dicoogle.issueExport('Modality:MR', ['Modality', 'PatientName']);
+      const uid = await dicoogle.issueExport('Modality:MR', ['Modality', 'PatientName']);
       assert.isString(uid, 'uid must be a string');
     });
     it("one field - should give a UID", async function() {
-      let uid = await dicoogle.issueExport('Modality:MR', 'SOPInstanceUID');
+      const uid = await dicoogle.issueExport('Modality:MR', 'SOPInstanceUID');
       assert.isString(uid, 'uid must be a string');
     });
   });
 
   describe('presets#fieldList()', function() {
     it("should return an array", async function() {
-      let fields = await dicoogle.presets.fieldList();
+      const fields = await dicoogle.presets.fieldList();
       assert.isArray(fields, 'fields must be an array');
       for (const field of fields) {
         assert.isString(field, 'field must be a string');
@@ -286,7 +286,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
 
   describe('Web UI Plugins', function() {
       it("#getWebUIPlugins(); should give all plugins", async function() {
-        let plugins = await dicoogle.getWebUIPlugins(null);
+        const plugins = await dicoogle.getWebUIPlugins(null);
         assert.isArray(plugins, 'plugins is an array');
         assert(plugins.length > 0, 'list of web UI plugins not empty');
         for (const p of plugins) {
@@ -297,7 +297,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
         }
       });
       it("#getWebUIPlugins(menu); should give all menu plugins", async function() {
-        let plugins = await dicoogle.getWebUIPlugins('menu');
+        const plugins = await dicoogle.getWebUIPlugins('menu');
         assert.isArray(plugins, 'plugins is an array');
         assert(plugins.length > 0, 'list of web UI plugins not empty');
         for (const p of plugins) {
@@ -311,12 +311,12 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
 
   describe('Plugin info', function() {
     it("#getPlugins(); should give all plugin information", async function() {
-      let resp = await dicoogle.getPlugins();
+      const resp = await dicoogle.getPlugins();
       assert.isObject(resp, 'resp is an object');
       assert.isArray(resp.plugins, 'resp.plugins is an array');
       assert.isArray(resp.sets, 'resp.sets is an array');
       assert.isArray(resp.dead, 'resp.dead is an array');
-      let {plugins, sets, dead} = resp;
+      const {plugins, sets, dead} = resp;
       assert(plugins.length > 0, 'list of plugins not empty');
       for (const p of plugins) {
           assert.isObject(p, 'plugin is an object');
@@ -336,10 +336,10 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
     });
 
     it("#getPlugins(type); should give plugin information only of that type", async function() {
-      let resp = await dicoogle.getPlugins('index');
+      const resp = await dicoogle.getPlugins('index');
       assert.isObject(resp, 'resp is an object');
       assert.isArray(resp.plugins, 'resp.plugins is an array');
-      let {plugins} = resp;
+      const {plugins} = resp;
       assert(plugins.length > 0, 'list of plugins not empty');
       for (const p of plugins) {
           assert.isObject(p, 'plugin is an object');
@@ -366,7 +366,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
   describe('Query/Retrieve service', function() {
     describe('queryRetrieve#getStatus()', function() {
       it("should inform of DICOM QR service status with no error", async function() {
-        let data = await dicoogle.queryRetrieve.getStatus();
+        const data = await dicoogle.queryRetrieve.getStatus();
         checkServiceInfo(data);
       });
     });
@@ -375,7 +375,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
         await dicoogle.queryRetrieve.stop();
       });
       it("and isRunning = false", async function() {
-        let data = await dicoogle.queryRetrieve.getStatus();
+        const data = await dicoogle.queryRetrieve.getStatus();
         assert.strictEqual(data.isRunning, false);
       });
     });
@@ -384,7 +384,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
           await dicoogle.queryRetrieve.start();
         });
         it("and isRunning = true", async function() {
-          let data = await dicoogle.queryRetrieve.getStatus();
+          const data = await dicoogle.queryRetrieve.getStatus();
           assert.strictEqual(data.isRunning, true);
         });
     });
@@ -396,7 +396,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
           });
         });
         it("and {autostart, port} changes", async function() {
-          let data = await dicoogle.queryRetrieve.getStatus();
+          const data = await dicoogle.queryRetrieve.getStatus();
           assert.strictEqual(data.autostart, true);
           assert.strictEqual(data.port, 7777);
         });
@@ -405,7 +405,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
     describe('Settings', function() {
       describe('Get', function() {
         it("queryRetrieve#getDicomQuerySettings(); should give all settings", async function() {
-          let data = await dicoogle.queryRetrieve.getDicomQuerySettings();
+          const data = await dicoogle.queryRetrieve.getDicomQuerySettings();
           for (const field in data) {
               assert.isNumber(data[field]);
           }
@@ -421,7 +421,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
 
   describe('User management service', () => {
     it('#list should provide the list of users', async () => {
-      let users = await dicoogle.users.list();
+      const users = await dicoogle.users.list();
       assert.isArray(users);
       for (const u of users) {
         assert.property(u, 'username');
@@ -430,7 +430,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
 
     it('#add and #remove should add and remove users', async () => {
       // add a new user
-      let addSuccess = await dicoogle.users.add('drze', 'verygoodsecret', false);
+      const addSuccess = await dicoogle.users.add('drze', 'verygoodsecret', false);
       assert.isTrue(addSuccess);
 
       // check that the user now exists
@@ -439,7 +439,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
       assert.deepInclude(users, {username: 'drze'});
 
       // now remove the user
-      let removeSuccess = await dicoogle.users.remove('drze');
+      const removeSuccess = await dicoogle.users.remove('drze');
       assert.isTrue(removeSuccess);
 
       // check the list again
@@ -451,7 +451,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
   describe('Storage service', function() {
     describe('#storage.getStatus()', function() {
       it("should inform of DICOM Storage service status with no error", async function() {
-        let data = await dicoogle.storage.getStatus();
+        const data = await dicoogle.storage.getStatus();
         checkServiceInfo(data);
       });
     });
@@ -460,7 +460,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
         await dicoogle.storage.stop();
       });
       it("and isRunning = false", async function() {
-        let data = await dicoogle.storage.getStatus();
+        const data = await dicoogle.storage.getStatus();
         assert.strictEqual(data.isRunning, false);
       });
     });
@@ -469,14 +469,14 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
         await dicoogle.storage.start();
       });
       it("and isRunning = true", async function() {
-        let data = await dicoogle.storage.getStatus();
+        const data = await dicoogle.storage.getStatus();
         assert.strictEqual(data.isRunning, true);
       });
     });
 
     describe('storage#configure()', function() {
       it("should give no error", async function() {
-        let outcome = await dicoogle.storage.configure({
+        const outcome = await dicoogle.storage.configure({
           autostart: true,
           port: 7777
         });
@@ -485,7 +485,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
         assert.strictEqual(outcome.port, 7777);
       });
       it("and {autostart, port} changes", async function() {
-        let data = await dicoogle.storage.getStatus();
+        const data = await dicoogle.storage.getStatus();
         assert.strictEqual(data.autostart, true);
         assert.strictEqual(data.port, 7777);
       });
@@ -493,7 +493,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
 
     describe('Remote Storage Servers', function() {
       it("storage#getRemoteServers(); should give a list", async function() {
-        let remotes = await dicoogle.storage.getRemoteServers();
+        const remotes = await dicoogle.storage.getRemoteServers();
         assert.isArray(remotes);
         for (const s of remotes) {
           assert.isObject(s);
@@ -512,7 +512,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
             ip: '10.0.0.144',
             port: 6646
           });
-          let remotes = await dicoogle.storage.getRemoteServers();
+          const remotes = await dicoogle.storage.getRemoteServers();
           assert.strictEqual(remotes.length, 3);
         });
         it("storage#addRemoteServer(); increases list to 4 stores", async function() {
@@ -523,24 +523,24 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
             description: 'our public store',
             public: true
           });
-          let remotes = await dicoogle.storage.getRemoteServers();
+          const remotes = await dicoogle.storage.getRemoteServers();
           assert.strictEqual(remotes.length, 4);
         });
       });
 
       describe('Remove', function() {
         it("storage#removeRemoteServer(store); reduces the list back to 2", async function() {
-          let removed = await dicoogle.storage.removeRemoteServer({
+          const removed = await dicoogle.storage.removeRemoteServer({
             aetitle: 'A_NEW_STORAGE',
             ip: '10.0.0.144',
             port: 6646
           });
           assert(removed);
-          let remotes = await dicoogle.storage.getRemoteServers();
+          const remotes = await dicoogle.storage.getRemoteServers();
           assert.strictEqual(remotes.length, 2);
         });
         it("storage#removeRemoteServer(aetitle); should work", async function() {
-          let removed = await dicoogle.storage.removeRemoteServer('STORAGE_NO_WAY');
+          const removed = await dicoogle.storage.removeRemoteServer('STORAGE_NO_WAY');
           assert.isFalse(removed);
         });
       });
@@ -549,7 +549,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
 
   describe('#getTransferSettings() all', function() {
     async function testTransferSettings() {
-      let data = await dicoogle.getTransferSyntaxSettings();
+      const data = await dicoogle.getTransferSyntaxSettings();
       assert.isArray(data);
       for (let i = 0; i < data.length; i++) {
         assert.isString(data[i].uid, 'uid must be a string');
@@ -573,7 +573,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
   describe('Indexer Settings', function() {
     describe('Get Indexer Settings', function() {
       it("#getIndexerSettings(); should give all settings", async function() {
-        let data = await dicoogle.getIndexerSettings();
+        const data = await dicoogle.getIndexerSettings();
         assert.deepEqual(data, {
           path: '/opt/data',
           zip: false,
@@ -586,7 +586,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
 
       function createTest(name, value) {
         return async () => {
-          let data = await dicoogle.getIndexerSettings(name);
+          const data = await dicoogle.getIndexerSettings(name);
           assert.strictEqual(data, value);
         };
       }
@@ -602,14 +602,14 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
     describe('Set Indexer Settings', function() {
       it("#setIndexerSettings('zip', true) should work ok", async function() {
         await dicoogle.setIndexerSettings(dicoogle.IndexerSettings.ZIP, true);
-        let out = await dicoogle.getIndexerSettings(dicoogle.IndexerSettings.ZIP);
+        const out = await dicoogle.getIndexerSettings(dicoogle.IndexerSettings.ZIP);
         assert.strictEqual(out, true);
       });
       it("#setIndexerSettings({'zip': false}) should work ok", async function() {
         const newSettings = {};
         newSettings[dicoogle.IndexerSettings.ZIP] = false;
         await dicoogle.setIndexerSettings(newSettings);
-        let out = await dicoogle.getIndexerSettings(dicoogle.IndexerSettings.ZIP);
+        const out = await dicoogle.getIndexerSettings(dicoogle.IndexerSettings.ZIP);
         assert.strictEqual(out, false);
       });
     });
@@ -619,7 +619,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
     let title;
     describe('#getAETitle()', function() {
       it("should give a valid AE title", async function() {
-        let aetitle = await dicoogle.getAETitle();
+        const aetitle = await dicoogle.getAETitle();
         assert.isString(aetitle);
         title = aetitle;
       });
@@ -630,7 +630,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
         await dicoogle.setAETitle(title);
       });
       it("and #getAETitle should give the AE title previously set", async function() {
-        let aetitle = await dicoogle.getAETitle();
+        const aetitle = await dicoogle.getAETitle();
         assert.strictEqual(aetitle, title);
       });
     });
@@ -639,12 +639,12 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
   describe('Dicoogle generic request', function() {
     describe("Get Dicoogle version", function() {
       it("#request('GET', 'ext/version') should give Dicoogle's version with no error", async function() {
-        let response = await dicoogle.request('GET', 'ext/version');
+        const response = await dicoogle.request('GET', 'ext/version');
         assert.isObject(response.body);
         assert.propertyVal(response.body, 'version', DICOOGLE_VERSION);
       });
       it("#request('GET', ['ext', 'version']) should give Dicoogle's version with no error", async function() {
-        let response = await dicoogle.request('GET', ['ext', 'version']);
+        const response = await dicoogle.request('GET', ['ext', 'version']);
         assert.isObject(response.body);
         assert.propertyVal(response.body, 'version', DICOOGLE_VERSION);
       });
@@ -655,7 +655,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
     it('Calling dicoogleClient() after initializing should work', async function() {
       const D = dicoogleClient();
 
-      let data = await D.getVersion();
+      const data = await D.getVersion();
       assert.isObject(data);
       assert.propertyVal(data, 'version', DICOOGLE_VERSION);
     });

--- a/test/base-promise.test.ts
+++ b/test/base-promise.test.ts
@@ -22,7 +22,7 @@ import {assert} from 'chai';
 import createMockedDicoogle from './mock/service-mock';
 const dicoogleClient = require('../src');
 
-const DICOOGLE_VERSION = '2.4.1-TEST';
+const DICOOGLE_VERSION = '3.1.0-TEST';
 
 function assertDicomUUID(uid) {
   assert.strictEqual(typeof uid, 'string', "UUID must be a string");

--- a/test/base.test.ts
+++ b/test/base.test.ts
@@ -790,8 +790,7 @@ describe('Dicoogle Client, callback API (under Node.js)', function() {
                 done();
             });
     }
-    it("should give transfer syntax settings (2.3.1)", testTransferSettings);
-    it("should give transfer syntax settings (patched)", testTransferSettings);
+    it("should give transfer syntax settings", testTransferSettings);
   });
 
   describe('#setTransferSyntaxOption() an option', function() {

--- a/test/base.test.ts
+++ b/test/base.test.ts
@@ -22,7 +22,7 @@ import {assert} from 'chai';
 import createMockedDicoogle from './mock/service-mock';
 const dicoogleClient = require('../src');
 
-const DICOOGLE_VERSION = '2.4.1-TEST';
+const DICOOGLE_VERSION = '3.1.0-TEST';
 
 function assertDicomUUID(uid) {
     assert.strictEqual(typeof uid, 'string', "UUID must be a string");

--- a/test/base.test.ts
+++ b/test/base.test.ts
@@ -38,7 +38,7 @@ function createCheckVersion(done) {
 }
 
 describe('Dicoogle Client, callback API (under Node.js)', function() {
-  var Dicoogle: ReturnType<typeof dicoogleClient>;
+  let Dicoogle: ReturnType<typeof dicoogleClient>;
   before(function initBaseURL() {
     Dicoogle = createMockedDicoogle();
     assert.strictEqual(Dicoogle.getBase(), 'http://127.0.0.1:8080');
@@ -148,8 +148,8 @@ describe('Dicoogle Client, callback API (under Node.js)', function() {
         assert.isArray(outcome.tasks);
         assert.strictEqual(outcome.tasks.length, 2);
         assert(outcome.count <= outcome.tasks.length);
-        for (var i = 0; i < outcome.tasks.length; i++) {
-            var task = outcome.tasks[i];
+        for (let i = 0; i < outcome.tasks.length; i++) {
+            const task = outcome.tasks[i];
             assert.isObject(task);
             assert.isString(task.taskUid);
             assert.isString(task.taskName);
@@ -174,7 +174,7 @@ describe('Dicoogle Client, callback API (under Node.js)', function() {
                 assert.isArray(outcome.tasks);
                 assert.strictEqual(outcome.tasks.length, 1);
                 assert.strictEqual(outcome.count, 1);
-                var task = outcome.tasks[0];
+                const task = outcome.tasks[0];
                 assert.isObject(task);
                 assert.isString(task.taskUid);
                 assert.notEqual(task.taskUid, 'f1b6588d-92c2-458c-8c77-e30d8706b662');
@@ -201,7 +201,7 @@ describe('Dicoogle Client, callback API (under Node.js)', function() {
         assert.equal(error, null);
         assert.property(outcome, 'results', 'outcome has results');
         assert.isArray(outcome.results, 'results must be an array');
-        for (var i = 0; i < outcome.results.length; i++) {
+        for (let i = 0; i < outcome.results.length; i++) {
             assert.isObject(outcome.results[i], 'all results must be objects');
             assert.isObject(outcome.results[i].fields, 'all results must have a fields object');
             assert.strictEqual(outcome.results[i].fields.Modality, 'MR', 'all results must be MR');
@@ -231,12 +231,12 @@ describe('Dicoogle Client, callback API (under Node.js)', function() {
         assert.equal(error, null);
         assert.property(outcome, 'results', 'outcome has results');
         assert.isArray(outcome.results, 'results must be an array');
-        for (var i = 0; i < outcome.results.length; i++) {
-            var patient = outcome.results[i];
+        for (let i = 0; i < outcome.results.length; i++) {
+            const patient = outcome.results[i];
             assert.isObject(patient, 'all patients must be objects');
             assert.isArray(patient.studies, 'all patients must have a studies array');
-            for (var j = 0; j < patient.studies.length; j++) {
-                var study = patient.studies[i];
+            for (let j = 0; j < patient.studies.length; j++) {
+                const study = patient.studies[i];
                 assert.isObject(study, 'all studies must be objects');
                 assertDicomUUID(study.studyInstanceUID);
                 assert.isArray(study.series, 'all studies must have a series array');
@@ -267,7 +267,7 @@ describe('Dicoogle Client, callback API (under Node.js)', function() {
         assert.equal(error, null);
         assert.property(outcome, 'results', 'outcome has results');
         assert.isArray(outcome.results, 'results must be an array');
-        for (var i = 0; i < outcome.results.length; i++) {
+        for (let i = 0; i < outcome.results.length; i++) {
             assert.isObject(outcome.results[i], 'all results must be objects');
             assert.isObject(outcome.results[i].fields, 'all results must have a fields object');
             assertDicomUUID(outcome.results[i].fields.SOPInstanceUID);
@@ -442,7 +442,7 @@ describe('Dicoogle Client, callback API (under Node.js)', function() {
         assert.isArray(resp.plugins, 'resp.plugins is an array');
         assert.isArray(resp.sets, 'resp.sets is an array');
         assert.isArray(resp.dead, 'resp.dead is an array');
-        let {plugins, sets, dead} = resp;
+        const {plugins, sets, dead} = resp;
         assert(plugins.length > 0, 'list of plugins not empty');
         for (const p of plugins) {
             assert.isObject(p, 'plugin is an object');
@@ -467,7 +467,7 @@ describe('Dicoogle Client, callback API (under Node.js)', function() {
         assert.equal(error, null);
         assert.isObject(resp, 'resp is an object');
         assert.isArray(resp.plugins, 'resp.plugins is an array');
-        let {plugins} = resp;
+        const {plugins} = resp;
         assert(plugins.length > 0, 'list of plugins not empty');
         for (const p of plugins) {
             assert.isObject(p, 'plugin is an object');
@@ -778,11 +778,11 @@ describe('Dicoogle Client, callback API (under Node.js)', function() {
             Dicoogle.getTransferSyntaxSettings(function (error, data) {
                 assert.equal(error, null);
                 assert.isArray(data);
-                for (var i = 0; i < data.length; i++) {
+                for (let i = 0; i < data.length; i++) {
                     assert.isString(data[i].uid, 'uid must be a string');
                     assert.isString(data[i].sop_name, 'sop_name must be a string');
                     assert.isArray(data[i].options);
-                    for (var j = 0; j < data[i].options.length; j++) {
+                    for (let j = 0; j < data[i].options.length; j++) {
                         assert.isString(data[i].options[j].name);
                         assert.isBoolean(data[i].options[j].value);
                     }
@@ -864,7 +864,7 @@ describe('Dicoogle Client, callback API (under Node.js)', function() {
   });
 
   describe('AE Title', function() {
-    var title;
+    let title;
     describe('#getAETitle()', function() {
         it("should give a valid AE title", function(done) {
             Dicoogle.getAETitle(function(error, aetitle) {

--- a/test/legacy.test.ts
+++ b/test/legacy.test.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2017  Universidade de Aveiro, DETI/IEETA, Bioinformatics Group - http://bioinformatics.ua.pt/
+ *
+ * This file is part of Dicoogle/dicoogle-client-js.
+ *
+ * Dicoogle/dicoogle-client-js is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Dicoogle/dicoogle-client-js is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Dicoogle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* eslint-env mocha */
+import {assert} from 'chai';
+import createMockedDicoogle from './mock/service-legacy-mock';
+const dicoogleClient = require('../src');
+
+const DICOOGLE_VERSION = '2.5.4-TEST';
+
+describe('Dicoogle Client against old Dicoogle servers (under Node.js)', function() {
+  /** @type {ReturnType<dicoogleClient>} */
+  let dicoogle;
+  before(function initBaseURL() {
+    dicoogle = createMockedDicoogle(8282);
+    assert.strictEqual(dicoogle.getBase(), 'http://127.0.0.1:8282');
+  });
+
+  describe('#getVersion()', function() {
+    it("should give Dicoogle's version with no error", async function() {
+      let {version} = await dicoogle.getVersion();
+      assert.strictEqual(version, DICOOGLE_VERSION);
+    });
+  });
+
+  describe('User management service', () => {
+    it('#list should provide the list of users', async () => {
+      let users = await dicoogle.users.list();
+      assert.isArray(users);
+      for (const u of users) {
+        assert.property(u, 'username');
+      }
+    });
+
+    it('#add and #remove should add and remove users (Dicoogle v2)', async () => {
+      // add a new user
+      let addSuccess = await dicoogle.users.add('drze', 'verygoodsecret', false);
+      assert.isTrue(addSuccess);
+
+      // check that the user now exists
+      let users;
+      users = await dicoogle.users.list();
+      assert.deepInclude(users, {username: 'drze'});
+
+      // now remove the user
+      let removeSuccess = await dicoogle.users.remove('drze');
+      assert.isTrue(removeSuccess);
+
+      // check the list again
+      users = await dicoogle.users.list();
+      assert.notDeepInclude(users, {username: 'drze'});
+    });
+  });
+
+  describe('#getTransferSettings() all', function() {
+    async function testTransferSettings() {
+      let data = await dicoogle.getTransferSyntaxSettings();
+      assert.isArray(data);
+      for (let i = 0; i < data.length; i++) {
+        assert.isString(data[i].uid, 'uid must be a string');
+        assert.isString(data[i].sop_name, 'sop_name must be a string');
+        assert.isArray(data[i].options);
+        for (let j = 0; j < data[i].options.length; j++) {
+          assert.isString(data[i].options[j].name);
+          assert.isBoolean(data[i].options[j].value);
+        }
+      }
+    }
+    it("should give transfer syntax settings (<=2.3.1)", testTransferSettings);
+  });
+
+});
+

--- a/test/legacy.test.ts
+++ b/test/legacy.test.ts
@@ -20,7 +20,6 @@
 /* eslint-env mocha */
 import {assert} from 'chai';
 import createMockedDicoogle from './mock/service-legacy-mock';
-const dicoogleClient = require('../src');
 
 const DICOOGLE_VERSION = '2.5.4-TEST';
 
@@ -34,14 +33,14 @@ describe('Dicoogle Client against old Dicoogle servers (under Node.js)', functio
 
   describe('#getVersion()', function() {
     it("should give Dicoogle's version with no error", async function() {
-      let {version} = await dicoogle.getVersion();
+      const {version} = await dicoogle.getVersion();
       assert.strictEqual(version, DICOOGLE_VERSION);
     });
   });
 
   describe('User management service', () => {
     it('#list should provide the list of users', async () => {
-      let users = await dicoogle.users.list();
+      const users = await dicoogle.users.list();
       assert.isArray(users);
       for (const u of users) {
         assert.property(u, 'username');
@@ -50,7 +49,7 @@ describe('Dicoogle Client against old Dicoogle servers (under Node.js)', functio
 
     it('#add and #remove should add and remove users (Dicoogle v2)', async () => {
       // add a new user
-      let addSuccess = await dicoogle.users.add('drze', 'verygoodsecret', false);
+      const addSuccess = await dicoogle.users.add('drze', 'verygoodsecret', false);
       assert.isTrue(addSuccess);
 
       // check that the user now exists
@@ -59,7 +58,7 @@ describe('Dicoogle Client against old Dicoogle servers (under Node.js)', functio
       assert.deepInclude(users, {username: 'drze'});
 
       // now remove the user
-      let removeSuccess = await dicoogle.users.remove('drze');
+      const removeSuccess = await dicoogle.users.remove('drze');
       assert.isTrue(removeSuccess);
 
       // check the list again
@@ -70,7 +69,7 @@ describe('Dicoogle Client against old Dicoogle servers (under Node.js)', functio
 
   describe('#getTransferSettings() all', function() {
     async function testTransferSettings() {
-      let data = await dicoogle.getTransferSyntaxSettings();
+      const data = await dicoogle.getTransferSyntaxSettings();
       assert.isArray(data);
       for (let i = 0; i < data.length; i++) {
         assert.isString(data[i].uid, 'uid must be a string');

--- a/test/mock/service-auth-mock.ts
+++ b/test/mock/service-auth-mock.ts
@@ -153,4 +153,4 @@ export default function createDicoogleMock(port = 8484) {
     }
 
     return dicoogleClient(BASE_URL);
-};
+}

--- a/test/mock/service-legacy-mock.ts
+++ b/test/mock/service-legacy-mock.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2017  Universidade de Aveiro, DETI/IEETA, Bioinformatics Group - http://bioinformatics.ua.pt/
+ *
+ * This file is part of Dicoogle/dicoogle-client-js.
+ *
+ * Dicoogle/dicoogle-client-js is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Dicoogle/dicoogle-client-js is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Dicoogle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const dicoogleClient = require('../../src');
+const nock = require('nock');
+const URL = require('url');
+const qs = require('querystring');
+
+function validateURI(uri) {
+    if (typeof uri !== 'string') {
+        return false;
+    }
+    return /^(file:)?[.-\w/%?&=]+$/.test(uri);
+}
+
+/** Use nock to intercept Dicoogle client requests.
+ * @param {number} [port] the TCP port to listen to
+ * @returns {object} a Dicoogle access object Dicoogle access object connected to a mock Dicoogle server.
+ */
+export default function createDicoogleMock(port = 8282): ReturnType<typeof dicoogleClient> {
+    const BASE_URL = `http://127.0.0.1:${port}`;
+    
+        // prepare Dicoogle server mock
+        const DICOOGLE_VERSION = '2.5.4-TEST';
+
+        const INDEXER_SETTINGS = {
+            path: '/opt/data',
+            zip: false,
+            effort: '100',
+            thumbnail: true,
+            thumbnailSize: '128',
+            watcher: false
+        };
+        /* eslint-disable */
+        const TRANSFER_SETTINGS = [{"uid":"1.2.840.10008.5.1.4.1.1.1","sop_name":"ComputedRadiographyImageStorage","options":[{"name":"ImplicitVRLittleEndian","value":true},{"name":"ExplicitVRLittleEndian","value":true},{"name":"DeflatedExplicitVRLittleEndian","value":false},{"name":"ExplicitVRBigEndian","value":false},{"name":"JPEGLossless","value":false},{"name":"JPEGLSLossless","value":true},{"name":"JPEGLosslessNonHierarchical14","value":false},{"name":"JPEG2000LosslessOnly","value":false},{"name":"JPEGBaseline1","value":true},{"name":"JPEGExtended24","value":false},{"name":"JPEGLSLossyNearLossless","value":false},{"name":"JPEG2000","value":false},{"name":"RLELossless","value":false},{"name":"MPEG2","value":false}]},{"uid":"1.2.840.10008.5.1.4.1.1.1.1","sop_name":"DigitalXRayImageStorageForPresentation","options":[{"name":"ImplicitVRLittleEndian","value":true},{"name":"ExplicitVRLittleEndian","value":true},{"name":"DeflatedExplicitVRLittleEndian","value":false},{"name":"ExplicitVRBigEndian","value":false},{"name":"JPEGLossless","value":false},{"name":"JPEGLSLossless","value":true},{"name":"JPEGLosslessNonHierarchical14","value":false},{"name":"JPEG2000LosslessOnly","value":false},{"name":"JPEGBaseline1","value":true},{"name":"JPEGExtended24","value":false},{"name":"JPEGLSLossyNearLossless","value":false},{"name":"JPEG2000","value":false},{"name":"RLELossless","value":false},{"name":"MPEG2","value":false}]}];
+
+        nock.cleanAll();
+
+        nock(BASE_URL)
+            // mock /version
+            .get('/ext/version')
+            .times(4)
+            .reply(200, {
+                version: DICOOGLE_VERSION
+            });
+
+        // mock indexer settings
+        nock(BASE_URL).get('/management/settings/index')
+            .once().reply(200, () => JSON.stringify(INDEXER_SETTINGS)); // in Dicoogle 2.3.1
+
+        nock(BASE_URL).get('/management/settings/transfer')
+            .once().reply(200, JSON.stringify(TRANSFER_SETTINGS)); // in Dicoogle 2.3.1
+        
+        nock(BASE_URL)
+            .get('/user')
+            .reply(200, {users: [
+                { username: "dicoogle" },
+                { username: "other" }
+            ]})
+            .post('/user')
+            .query(true)
+            .reply(405)
+            .put('/user')
+            .query(({username, password, admin}) => {
+                return username === 'drze' &&
+                    typeof password === 'string' &&
+                    password.length > 0 &&
+                    (admin === undefined || admin === 'true' || admin === 'false');
+            })
+            .reply(200, {success: true})
+            .get('/user')
+            .reply(200, {users: [
+                { username: "dicoogle" },
+                { username: "drze" },
+                { username: "other" }
+            ]})
+            .delete('/user/drze')
+            .reply(200, {success: true})
+            .get('/user')
+            .reply(200, {users: [
+                { username: "dicoogle" },
+                { username: "other" }
+            ]});
+
+    return dicoogleClient(BASE_URL);
+};

--- a/test/mock/service-legacy-mock.ts
+++ b/test/mock/service-legacy-mock.ts
@@ -19,15 +19,6 @@
 
 const dicoogleClient = require('../../src');
 const nock = require('nock');
-const URL = require('url');
-const qs = require('querystring');
-
-function validateURI(uri) {
-    if (typeof uri !== 'string') {
-        return false;
-    }
-    return /^(file:)?[.-\w/%?&=]+$/.test(uri);
-}
 
 /** Use nock to intercept Dicoogle client requests.
  * @param {number} [port] the TCP port to listen to

--- a/test/mock/service-mock.ts
+++ b/test/mock/service-mock.ts
@@ -633,9 +633,7 @@ export default function createDicoogleMock(port = 8080): ReturnType<typeof dicoo
 
         // mock indexer settings
         nock(BASE_URL).get('/management/settings/index')
-            .once().reply(200, () => JSON.stringify(INDEXER_SETTINGS)); // in Dicoogle 2.3.1
-        nock(BASE_URL).get('/management/settings/index')
-            .reply(200, () => INDEXER_SETTINGS); // with patched Dicoogle
+            .reply(200, () => INDEXER_SETTINGS); // patched Dicoogle
         // getters
         nock(BASE_URL)
             .get('/management/settings/index/path')
@@ -736,7 +734,7 @@ export default function createDicoogleMock(port = 8080): ReturnType<typeof dicoo
                 { username: "dicoogle" },
                 { username: "other" }
             ]})
-            .put('/user')
+            .post('/user')
             .query(({username, password, admin}) => {
                 return username === 'drze' &&
                     typeof password === 'string' &&

--- a/test/mock/service-mock.ts
+++ b/test/mock/service-mock.ts
@@ -177,12 +177,12 @@ export default function createDicoogleMock(port = 8080): ReturnType<typeof dicoo
 2016-05-24T15:05:52,808 | Plugins initialized`;
 
         let AETitle = 'TESTSRV';
-        let Storage = {
+        const Storage = {
             isRunning: true,
             autostart: false,
             port: 6666
         };
-        let QR = {
+        const QR = {
             isRunning: true,
             autostart: false,
             port: 1045
@@ -757,4 +757,4 @@ export default function createDicoogleMock(port = 8080): ReturnType<typeof dicoo
             ]});
 
     return dicoogleClient(BASE_URL);
-};
+}

--- a/test/mock/service-mock.ts
+++ b/test/mock/service-mock.ts
@@ -37,7 +37,7 @@ export default function createDicoogleMock(port = 8080): ReturnType<typeof dicoo
     const BASE_URL = `http://127.0.0.1:${port}`;
     
         // prepare Dicoogle server mock
-        const DICOOGLE_VERSION = '2.4.1-TEST';
+        const DICOOGLE_VERSION = '3.1.0-TEST';
 
         const SEARCH_RESULTS = [
             {

--- a/test/mock/service-mock.ts
+++ b/test/mock/service-mock.ts
@@ -750,8 +750,7 @@ export default function createDicoogleMock(port = 8080): ReturnType<typeof dicoo
                 { username: "drze" },
                 { username: "other" }
             ]})
-            .delete('/user')
-            .query({username: 'drze'})
+            .delete('/user/drze')
             .reply(200, {success: true})
             .get('/user')
             .reply(200, {users: [


### PR DESCRIPTION
- Adding new users should use the POST method (since Dicoogle 3). It falls back to PUT if the method is not allowed.
- Removing users is done by passing the username into the path rather than by query string.

This will be patched directly onto the dicoogle-client v5 release line.