### PR TITLE
Fix operations to add and delete users (v6)

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -7,9 +7,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, release/5.x ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, release/5.x ]
 
 jobs:
   build:

--- a/src/users.ts
+++ b/src/users.ts
@@ -50,7 +50,15 @@ export class UserService {
      * @param admin whether the account is an administrator
      */
     add(username: string, password: password, admin: boolean, callback?: (error: Error | null, success?: boolean) => void): Promise<boolean> {
-        return andCall(this.socket.put(Endpoints.USER).query({username, password, admin})
+        return andCall(this.socket.post(Endpoints.USER).query({username, password, admin})
+            .catch((err) => {
+                if (err.status === 405) {
+                    // method not allowed means that we're using Dicoogle 2,
+                    // so we try again with the PUT method
+                    return this.socket.put(Endpoints.USER).query({username, password, admin});
+                }
+                throw err;
+            })
             .then((res) => res.body.success), callback);
     }
 

--- a/src/users.ts
+++ b/src/users.ts
@@ -59,7 +59,7 @@ export class UserService {
      * @param username the identifier of the user to remove
      */
     remove(username: string, callback?: (error: Error | null, removed?: boolean) => void): Promise<boolean> {
-        return andCall(this.socket.request('DELETE', Endpoints.USER).query({username})
+        return andCall(this.socket.request('DELETE', [Endpoints.USER, username])
             .then((res) => res.body.success), callback);
     }
 }

--- a/test/base-promise.test.ts
+++ b/test/base-promise.test.ts
@@ -561,8 +561,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
         }
       }
     }
-    it("should give transfer syntax settings (2.3.1)", testTransferSettings);
-    it("should give transfer syntax settings (patched)", testTransferSettings);
+    it("should give transfer syntax settings", testTransferSettings);
   });
 
   describe('#setTransferSyntaxOption() an option', function() {

--- a/test/base-promise.test.ts
+++ b/test/base-promise.test.ts
@@ -23,7 +23,7 @@ import createMockedDicoogle from './mock/service-mock';
 import dicoogleClient, { DicoogleAccess } from '../src';
 import type { ServiceStatus } from '../src/service';
 
-const DICOOGLE_VERSION = '2.4.1-TEST';
+const DICOOGLE_VERSION = '3.1.0-TEST';
 
 function assertDicomUUID(uid) {
   assert.strictEqual(typeof uid, 'string', "UUID must be a string");

--- a/test/base.test.ts
+++ b/test/base.test.ts
@@ -795,8 +795,7 @@ describe('Dicoogle Client, callback API (under Node.js)', function() {
                 done();
             });
     }
-    it("should give transfer syntax settings (2.3.1)", testTransferSettings);
-    it("should give transfer syntax settings (patched)", testTransferSettings);
+    it("should give transfer syntax settings", testTransferSettings);
   });
 
   describe('#setTransferSyntaxOption() an option', function() {

--- a/test/base.test.ts
+++ b/test/base.test.ts
@@ -22,7 +22,7 @@ import {assert} from 'chai';
 import createMockedDicoogle from './mock/service-mock';
 import dicoogleClient, { DicoogleAccess } from '../src';
 
-const DICOOGLE_VERSION = '2.4.1-TEST';
+const DICOOGLE_VERSION = '3.1.0-TEST';
 
 function assertDicomUUID(uid) {
     assert.strictEqual(typeof uid, 'string', "UUID must be a string");

--- a/test/legacy.test.ts
+++ b/test/legacy.test.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2017  Universidade de Aveiro, DETI/IEETA, Bioinformatics Group - http://bioinformatics.ua.pt/
+ *
+ * This file is part of Dicoogle/dicoogle-client-js.
+ *
+ * Dicoogle/dicoogle-client-js is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Dicoogle/dicoogle-client-js is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Dicoogle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* eslint-env mocha */
+import {assert} from 'chai';
+import createMockedDicoogle from './mock/service-legacy-mock';
+const dicoogleClient = require('../src');
+
+const DICOOGLE_VERSION = '2.5.4-TEST';
+
+describe('Dicoogle Client against old Dicoogle servers (under Node.js)', function() {
+  /** @type {ReturnType<dicoogleClient>} */
+  let dicoogle;
+  before(function initBaseURL() {
+    dicoogle = createMockedDicoogle(8282);
+    assert.strictEqual(dicoogle.getBase(), 'http://127.0.0.1:8282');
+  });
+
+  describe('#getVersion()', function() {
+    it("should give Dicoogle's version with no error", async function() {
+      let {version} = await dicoogle.getVersion();
+      assert.strictEqual(version, DICOOGLE_VERSION);
+    });
+  });
+
+  describe('User management service', () => {
+    it('#list should provide the list of users', async () => {
+      let users = await dicoogle.users.list();
+      assert.isArray(users);
+      for (const u of users) {
+        assert.property(u, 'username');
+      }
+    });
+
+    it('#add and #remove should add and remove users (Dicoogle v2)', async () => {
+      // add a new user
+      let addSuccess = await dicoogle.users.add('drze', 'verygoodsecret', false);
+      assert.isTrue(addSuccess);
+
+      // check that the user now exists
+      let users;
+      users = await dicoogle.users.list();
+      assert.deepInclude(users, {username: 'drze'});
+
+      // now remove the user
+      let removeSuccess = await dicoogle.users.remove('drze');
+      assert.isTrue(removeSuccess);
+
+      // check the list again
+      users = await dicoogle.users.list();
+      assert.notDeepInclude(users, {username: 'drze'});
+    });
+  });
+
+  describe('#getTransferSettings() all', function() {
+    async function testTransferSettings() {
+      let data = await dicoogle.getTransferSyntaxSettings();
+      assert.isArray(data);
+      for (let i = 0; i < data.length; i++) {
+        assert.isString(data[i].uid, 'uid must be a string');
+        assert.isString(data[i].sop_name, 'sop_name must be a string');
+        assert.isArray(data[i].options);
+        for (let j = 0; j < data[i].options.length; j++) {
+          assert.isString(data[i].options[j].name);
+          assert.isBoolean(data[i].options[j].value);
+        }
+      }
+    }
+    it("should give transfer syntax settings (<=2.3.1)", testTransferSettings);
+  });
+
+});
+

--- a/test/legacy.test.ts
+++ b/test/legacy.test.ts
@@ -20,13 +20,12 @@
 /* eslint-env mocha */
 import {assert} from 'chai';
 import createMockedDicoogle from './mock/service-legacy-mock';
-const dicoogleClient = require('../src');
+import { DicoogleAccess } from '../src';
 
 const DICOOGLE_VERSION = '2.5.4-TEST';
 
 describe('Dicoogle Client against old Dicoogle servers (under Node.js)', function() {
-  /** @type {ReturnType<dicoogleClient>} */
-  let dicoogle;
+  let dicoogle: DicoogleAccess;
   before(function initBaseURL() {
     dicoogle = createMockedDicoogle(8282);
     assert.strictEqual(dicoogle.getBase(), 'http://127.0.0.1:8282');
@@ -34,14 +33,14 @@ describe('Dicoogle Client against old Dicoogle servers (under Node.js)', functio
 
   describe('#getVersion()', function() {
     it("should give Dicoogle's version with no error", async function() {
-      let {version} = await dicoogle.getVersion();
+      const {version} = await dicoogle.getVersion();
       assert.strictEqual(version, DICOOGLE_VERSION);
     });
   });
 
   describe('User management service', () => {
     it('#list should provide the list of users', async () => {
-      let users = await dicoogle.users.list();
+      const users = await dicoogle.users.list();
       assert.isArray(users);
       for (const u of users) {
         assert.property(u, 'username');
@@ -50,7 +49,7 @@ describe('Dicoogle Client against old Dicoogle servers (under Node.js)', functio
 
     it('#add and #remove should add and remove users (Dicoogle v2)', async () => {
       // add a new user
-      let addSuccess = await dicoogle.users.add('drze', 'verygoodsecret', false);
+      const addSuccess = await dicoogle.users.add('drze', 'verygoodsecret', false);
       assert.isTrue(addSuccess);
 
       // check that the user now exists
@@ -59,7 +58,7 @@ describe('Dicoogle Client against old Dicoogle servers (under Node.js)', functio
       assert.deepInclude(users, {username: 'drze'});
 
       // now remove the user
-      let removeSuccess = await dicoogle.users.remove('drze');
+      const removeSuccess = await dicoogle.users.remove('drze');
       assert.isTrue(removeSuccess);
 
       // check the list again
@@ -70,7 +69,7 @@ describe('Dicoogle Client against old Dicoogle servers (under Node.js)', functio
 
   describe('#getTransferSettings() all', function() {
     async function testTransferSettings() {
-      let data = await dicoogle.getTransferSyntaxSettings();
+      const data = await dicoogle.getTransferSyntaxSettings();
       assert.isArray(data);
       for (let i = 0; i < data.length; i++) {
         assert.isString(data[i].uid, 'uid must be a string');

--- a/test/mock/service-legacy-mock.ts
+++ b/test/mock/service-legacy-mock.ts
@@ -17,17 +17,8 @@
  * along with Dicoogle.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const dicoogleClient = require('../../src');
-const nock = require('nock');
-const URL = require('url');
-const qs = require('querystring');
-
-function validateURI(uri) {
-    if (typeof uri !== 'string') {
-        return false;
-    }
-    return /^(file:)?[.-\w/%?&=]+$/.test(uri);
-}
+import dicoogleClient from '../../src';
+import nock from 'nock';
 
 /** Use nock to intercept Dicoogle client requests.
  * @param {number} [port] the TCP port to listen to

--- a/test/mock/service-legacy-mock.ts
+++ b/test/mock/service-legacy-mock.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2017  Universidade de Aveiro, DETI/IEETA, Bioinformatics Group - http://bioinformatics.ua.pt/
+ *
+ * This file is part of Dicoogle/dicoogle-client-js.
+ *
+ * Dicoogle/dicoogle-client-js is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Dicoogle/dicoogle-client-js is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Dicoogle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const dicoogleClient = require('../../src');
+const nock = require('nock');
+const URL = require('url');
+const qs = require('querystring');
+
+function validateURI(uri) {
+    if (typeof uri !== 'string') {
+        return false;
+    }
+    return /^(file:)?[.-\w/%?&=]+$/.test(uri);
+}
+
+/** Use nock to intercept Dicoogle client requests.
+ * @param {number} [port] the TCP port to listen to
+ * @returns {object} a Dicoogle access object Dicoogle access object connected to a mock Dicoogle server.
+ */
+export default function createDicoogleMock(port = 8282): ReturnType<typeof dicoogleClient> {
+    const BASE_URL = `http://127.0.0.1:${port}`;
+    
+        // prepare Dicoogle server mock
+        const DICOOGLE_VERSION = '2.5.4-TEST';
+
+        const INDEXER_SETTINGS = {
+            path: '/opt/data',
+            zip: false,
+            effort: '100',
+            thumbnail: true,
+            thumbnailSize: '128',
+            watcher: false
+        };
+        /* eslint-disable */
+        const TRANSFER_SETTINGS = [{"uid":"1.2.840.10008.5.1.4.1.1.1","sop_name":"ComputedRadiographyImageStorage","options":[{"name":"ImplicitVRLittleEndian","value":true},{"name":"ExplicitVRLittleEndian","value":true},{"name":"DeflatedExplicitVRLittleEndian","value":false},{"name":"ExplicitVRBigEndian","value":false},{"name":"JPEGLossless","value":false},{"name":"JPEGLSLossless","value":true},{"name":"JPEGLosslessNonHierarchical14","value":false},{"name":"JPEG2000LosslessOnly","value":false},{"name":"JPEGBaseline1","value":true},{"name":"JPEGExtended24","value":false},{"name":"JPEGLSLossyNearLossless","value":false},{"name":"JPEG2000","value":false},{"name":"RLELossless","value":false},{"name":"MPEG2","value":false}]},{"uid":"1.2.840.10008.5.1.4.1.1.1.1","sop_name":"DigitalXRayImageStorageForPresentation","options":[{"name":"ImplicitVRLittleEndian","value":true},{"name":"ExplicitVRLittleEndian","value":true},{"name":"DeflatedExplicitVRLittleEndian","value":false},{"name":"ExplicitVRBigEndian","value":false},{"name":"JPEGLossless","value":false},{"name":"JPEGLSLossless","value":true},{"name":"JPEGLosslessNonHierarchical14","value":false},{"name":"JPEG2000LosslessOnly","value":false},{"name":"JPEGBaseline1","value":true},{"name":"JPEGExtended24","value":false},{"name":"JPEGLSLossyNearLossless","value":false},{"name":"JPEG2000","value":false},{"name":"RLELossless","value":false},{"name":"MPEG2","value":false}]}];
+
+        nock.cleanAll();
+
+        nock(BASE_URL)
+            // mock /version
+            .get('/ext/version')
+            .times(4)
+            .reply(200, {
+                version: DICOOGLE_VERSION
+            });
+
+        // mock indexer settings
+        nock(BASE_URL).get('/management/settings/index')
+            .once().reply(200, () => JSON.stringify(INDEXER_SETTINGS)); // in Dicoogle 2.3.1
+
+        nock(BASE_URL).get('/management/settings/transfer')
+            .once().reply(200, JSON.stringify(TRANSFER_SETTINGS)); // in Dicoogle 2.3.1
+        
+        nock(BASE_URL)
+            .get('/user')
+            .reply(200, {users: [
+                { username: "dicoogle" },
+                { username: "other" }
+            ]})
+            .post('/user')
+            .query(true)
+            .reply(405)
+            .put('/user')
+            .query(({username, password, admin}) => {
+                return username === 'drze' &&
+                    typeof password === 'string' &&
+                    password.length > 0 &&
+                    (admin === undefined || admin === 'true' || admin === 'false');
+            })
+            .reply(200, {success: true})
+            .get('/user')
+            .reply(200, {users: [
+                { username: "dicoogle" },
+                { username: "drze" },
+                { username: "other" }
+            ]})
+            .delete('/user/drze')
+            .reply(200, {success: true})
+            .get('/user')
+            .reply(200, {users: [
+                { username: "dicoogle" },
+                { username: "other" }
+            ]});
+
+    return dicoogleClient(BASE_URL);
+};

--- a/test/mock/service-mock.ts
+++ b/test/mock/service-mock.ts
@@ -752,8 +752,7 @@ export default function createDicoogleMock(port = 8080): ReturnType<typeof dicoo
                 { username: "drze" },
                 { username: "other" }
             ]})
-            .delete('/user')
-            .query({username: 'drze'})
+            .delete('/user/drze')
             .reply(200, {success: true})
             .get('/user')
             .reply(200, {users: [

--- a/test/mock/service-mock.ts
+++ b/test/mock/service-mock.ts
@@ -37,7 +37,7 @@ export default function createDicoogleMock(port = 8080): ReturnType<typeof dicoo
     const BASE_URL = `http://127.0.0.1:${port}`;
     
         // prepare Dicoogle server mock
-        const DICOOGLE_VERSION = '2.4.1-TEST';
+        const DICOOGLE_VERSION = '3.1.0-TEST';
 
         const SEARCH_RESULTS = [
             {

--- a/test/mock/service-mock.ts
+++ b/test/mock/service-mock.ts
@@ -635,9 +635,7 @@ export default function createDicoogleMock(port = 8080): ReturnType<typeof dicoo
 
         // mock indexer settings
         nock(BASE_URL).get('/management/settings/index')
-            .once().reply(200, () => JSON.stringify(INDEXER_SETTINGS)); // in Dicoogle 2.3.1
-        nock(BASE_URL).get('/management/settings/index')
-            .reply(200, () => INDEXER_SETTINGS); // with patched Dicoogle
+            .reply(200, () => INDEXER_SETTINGS); // patched Dicoogle
         // getters
         nock(BASE_URL)
             .get('/management/settings/index/path')
@@ -738,7 +736,7 @@ export default function createDicoogleMock(port = 8080): ReturnType<typeof dicoo
                 { username: "dicoogle" },
                 { username: "other" }
             ]})
-            .put('/user')
+            .post('/user')
             .query(({username, password, admin}) => {
                 return username === 'drze' &&
                     typeof password === 'string' &&


### PR DESCRIPTION
- Adding new users should use the POST method (since Dicoogle 3). It falls back to PUT if the method is not allowed.
- Removing users is done by passing the username into the path rather than by query string.

Equivalent to #52, but adapted for the future major version.