### PR TITLE
Extend API with service hostname support (v5.x)

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,8 +18,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16, lts/*, latest]
-        # Minimum supported version, latest LTS, and latest stable
+        node-version: [16, lts/*]
+        # Minimum supported version and latest LTS
 
     steps:
     - uses: actions/checkout@v3

--- a/src/service.ts
+++ b/src/service.ts
@@ -29,6 +29,11 @@ export interface ServiceConfiguration {
   autostart?: boolean,
   /** the TCP port that the service should listen to */
   port?: number,
+  /** the hostname that the service should bind to
+   *
+   * _Note:_ Available since Dicoogle 3.5.0
+   */
+  hostname?: string,
 }
 
 /** Full status of the DICOM service. */
@@ -39,6 +44,11 @@ export interface ServiceStatus {
   autostart: boolean,
   /** the TCP port that the service listens to */
   port: number,
+  /** the hostname that the service is bound to
+   *
+   * _Note:_ Available since Dicoogle 3.5.0
+   */
+  hostname?: string,
 }
 
 /** A DICOM service change outcome object,
@@ -52,15 +62,15 @@ export interface ServiceChangeOutcome extends ServiceConfiguration {
 }
 
 export interface RemoteStorage {
-  /// {string} aetitle
+  /** called AE title of the remote DICOM node */
   aetitle: string,
-  /// {string} ip
+  /** IP address or hostname of the remote DICOM node */
   ip: string,
-  /// {number} port
+  /** TCP port to the remote DICOM node */
   port: number,
-  /// {?string} description
+  /** Free text description of the DICOM node */
   description?: string,
-  /// {?boolean} public
+  /** Whether the DICOM node is public */
   public?: boolean,
 }
 
@@ -94,9 +104,9 @@ class BaseService {
    * @param callback the callback function
    */
   configure(config: ServiceConfiguration, callback?: (error: Error | null, outcome: ServiceChangeOutcome | undefined) => void): Promise<ServiceChangeOutcome> {
-    const {running, autostart, port} = config;
+    const {running, autostart, port, hostname} = config;
     return andCall(this._socket.post(this._endpoint)
-      .query({running, autostart, port})
+      .query({running, autostart, hostname, port})
       .then((resp) => resp.body), callback);
   }
 

--- a/test/base-promise.test.ts
+++ b/test/base-promise.test.ts
@@ -392,6 +392,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
         it("should give no error", async function() {
           await dicoogle.queryRetrieve.configure({
             autostart: true,
+            hostname: '127.1',
             port: 7777
           });
         });
@@ -399,6 +400,7 @@ describe('Dicoogle Client, Promise API (under Node.js)', function() {
           const data = await dicoogle.queryRetrieve.getStatus();
           assert.strictEqual(data.autostart, true);
           assert.strictEqual(data.port, 7777);
+          assert.strictEqual(data.hostname, '127.1');
         });
     });
 

--- a/test/mock/service-mock.ts
+++ b/test/mock/service-mock.ts
@@ -507,8 +507,8 @@ export default function createDicoogleMock(port = 8080): ReturnType<typeof dicoo
             .query((query) => !!(query.autostart || query.port || query.hostname))
             .reply(200, function() {
                 // pass whatever is in the query parameters
-                let query = URL.parse(this.req.path, true).query;
-                let out: {[key: string]: any} = {
+                const {query} = URL.parse(this.req.path, true);
+                const out: {[key: string]: string | boolean | number} = {
                     success: true,
                 };
 


### PR DESCRIPTION
Predicted to be released in Dicoogle 3.5.0.

This adds the API to the 5.x line of dicoogle-client.